### PR TITLE
Add `build/` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info/
 __pycache__/
+build/


### PR DESCRIPTION
 I noticed this because `build/` was leftover after I ran `uv tool
install .`.  Normally, `uv` seems to delete it, but it still seems to be used temporarily during `uv build` (so `jj` could waste time snapshotting that).

I'm not sure how important it is to add it to .gitignore, but I don't think it can hurt.